### PR TITLE
Redefine the SPI speeds per older SD lib

### DIFF
--- a/src/SdCard/SdInfo.h
+++ b/src/SdCard/SdInfo.h
@@ -107,6 +107,7 @@ const uint8_t SD_CARD_TYPE_SDHC = 3;
 #define SD_SCK_HZ(maxSpeed) SPISettings(maxSpeed, MSBFIRST, SPI_MODE0)
 #define SD_SCK_MHZ(maxMhz) SPISettings(1000000UL*maxMhz, MSBFIRST, SPI_MODE0)
 // SPI divisor constants
+#ifndef ESP8266
 /** Set SCK to max rate of F_CPU/2. */
 #define SPI_FULL_SPEED SD_SCK_MHZ(50)
 /** Set SCK rate to F_CPU/3 for Due */
@@ -121,6 +122,13 @@ const uint8_t SD_CARD_TYPE_SDHC = 3;
 #define SPI_EIGHTH_SPEED SD_SCK_HZ(F_CPU/16)
 /** Set SCK rate to F_CPU/32. */
 #define SPI_SIXTEENTH_SPEED SD_SCK_HZ(F_CPU/32)
+#else
+// ESP8266 backward compatible options from old SD.h library
+#define SPI_FULL_SPEED       SD_SCK_HZ(80000000)
+#define SPI_HALF_SPEED       SD_SCK_HZ(40000000)
+#define SPI_QUARTER_SPEED    SD_SCK_HZ(20000000)
+#endif
+
 //------------------------------------------------------------------------------
 // SD operation timeouts
 /** CMD0 retry count */


### PR DESCRIPTION
The SPI bus speed macros are not compatible w/the 8266 clocking and
cause failure when used.  Use the settings for full, half, and quarted
speed from the older, Arduino.cc copy of the libs that @igrr fixed.