### PR TITLE
Add a yield every 5000 clusters searched by FatVolume

### DIFF
--- a/src/FatLib/FatVolume.cpp
+++ b/src/FatLib/FatVolume.cpp
@@ -84,7 +84,15 @@ bool FatVolume::allocateCluster(uint32_t current, uint32_t* next) {
     find = m_allocSearchStart;
     setStart = true;
   }
+  // Following loop may iterate over up to 268 million clusters, so we need to allow
+  // the OS/hardware to do its work occasionally during the search or a WDT error will
+  // occur on the ESP8266.
+  int yieldCnt = 5000;
   while (1) {
+    if (!(--yieldCnt)) {
+        yieldCnt = 5000;
+        SysCall::yield();
+    }
     find++;
     if (find > m_lastCluster) {
       if (setStart) {
@@ -146,7 +154,15 @@ bool FatVolume::allocContiguous(uint32_t count, uint32_t* firstCluster) {
   endCluster = bgnCluster = m_allocSearchStart + 1;
 
   // search the FAT for free clusters
+  // Following loop may iterate over up to 268 million clusters, so we need to allow
+  // the OS/hardware to do its work occasionally during the search or a WDT error will
+  // occur on the ESP8266.
+  int yieldCnt = 5000;
   while (1) {
+    if (!(--yieldCnt)) {
+        yieldCnt = 5000;
+        SysCall::yield();
+    }
     if (endCluster > m_lastCluster) {
       // Can't find space.
       DBG_FAIL_MACRO;


### PR DESCRIPTION
FAT filesystems may have up to ~270 million clusters, and the SdFat
library needs to perform a linear scan on them to find free clusters.
WDT timeouts will occur on systems that have periodic yield
requirements when large scans are needed.

Add in a OS yield (no-op unless needed by the specific uController)
every 5,000 cluster entries.

Fixes https://github.com/esp8266/Arduino/issues/1255