### PR TITLE
Add namespace to O_RDWR, O_CREAT, O_AT_END

### DIFF
--- a/src/FatLib/ArduinoFiles.h
+++ b/src/FatLib/ArduinoFiles.h
@@ -39,7 +39,7 @@ namespace sdfat {
 /** Arduino SD.h style flag for open for read. */
 #define FILE_READ O_RDONLY
 /** Arduino SD.h style flag for open at EOF for read/write with create. */
-#define FILE_WRITE (O_RDWR | O_CREAT | O_AT_END)
+#define FILE_WRITE (sdfat::O_RDWR | sdfat::O_CREAT | sdfat::O_AT_END)
 //==============================================================================
 /**
  * \class PrintFile


### PR DESCRIPTION
When compiling the project, I am getting an error stating these three variables are not defined.
```
/Users/danielbuechele/Library/Arduino15/packages/esp8266/hardware/esp8266/2.6.3/libraries/ESP8266SdFat/src/FatLib/ArduinoFiles.h:42:21: error: 'O_RDWR' was not declared in this scope
 #define FILE_WRITE (O_RDWR | O_CREAT | O_AT_END)
```
Adding the namespace to these variables fixes the problem for me. Can we add the namespace like this?