### PR TITLE
Update to new delay(0) replacement esp_yield() from ESP8266 Core for Arduino

### DIFF
--- a/src/common/SysCall.h
+++ b/src/common/SysCall.h
@@ -94,8 +94,8 @@ inline void SysCall::yield() {
   // Use the external Arduino yield() function.
 #if defined(ESP8266)
   // SdFat uses `SysCall::yield()` from within OS callbacks, a no-no.
-  // Use delay(0) instead, which is safe under all circumstances
-  ::delay(0);
+  // Use esp_yield() instead, which is safe under all circumstances
+  ::esp_yield();
 #else
   ::yield();
 #endif


### PR DESCRIPTION
In PR https://github.com/esp8266/Arduino/pull/7148, the issue that `delay(0)` has to be used in calls that may occur from the SYS context, which isn't self-describing, is resolved.

Please merge this PR whenever above PR gets merged into https://github.com/esp8266/Arduino