### PR TITLE
availableSpaceForWrite: allow to return a strictly positive number when space is available for write

### DIFF
--- a/src/FatLib/FatFile.cpp
+++ b/src/FatLib/FatFile.cpp
@@ -1498,22 +1498,38 @@ size_t FatFile::write(const void* buf, size_t nbyte) {
 //-------------------------------------------------------
 // EFP3 - Match upstream Arduino hack
 int FatFile::availableSpaceForWrite() {
-  // error if not a normal file or is read-only
-  if (!isWritable() || m_vol->m_blockDev->isBusy()) {
+  if (!isWritable()) {
+    // error if not a normal file or is read-only
     return 0;
   }
+
+  if (m_vol->m_blockDev->isBusy()) {
+    // SdSpiCard::isTimedOut is private...
+    decltype(millis()) t0 = millis();
+    while (m_vol->m_blockDev->isBusy()) {
+      if ((millis() - t0) > SD_READ_TIMEOUT) {
+        // busy for too long ?
+        return 0;
+      }
+      yield();
+    }
+  }
+
   // seek to end of file if append flag
   if ((m_flags & FILE_FLAG_APPEND)) {
     if (!seekSet(m_fileSize)) {
       return 0;
     }
   }
-  uint8_t sectorOfCluster = m_vol->sectorOfCluster(m_curPosition);
+
+  // remaining space in current sector
   uint16_t sectorOffset = m_curPosition & m_vol->sectorMask();
-  if (sectorOfCluster == 0 && sectorOffset == 0) {
-    return 0;
+  int afw = m_vol->bytesPerSector() - sectorOffset - 1;
+  if (afw == 0 && m_vol->freeClusterCount() > 0) {
+    // a new sector can be available
+    afw = m_vol->bytesPerSector();
   }
-  return m_vol->bytesPerSector() - sectorOffset - 1;
+  return afw;
 }
 //-------------------------------------------------------
 

--- a/src/FatLib/FatFile.cpp
+++ b/src/FatLib/FatFile.cpp
@@ -1498,21 +1498,10 @@ size_t FatFile::write(const void* buf, size_t nbyte) {
 //-------------------------------------------------------
 // EFP3 - Match upstream Arduino hack
 int FatFile::availableSpaceForWrite() {
-  if (!isWritable()) {
+  // error if not a normal file or is read-only
+  if (!isWritable() || m_vol->m_blockDev->isBusy()) {
     // error if not a normal file or is read-only
     return 0;
-  }
-
-  if (m_vol->m_blockDev->isBusy()) {
-    // SdSpiCard::isTimedOut is private...
-    decltype(millis()) t0 = millis();
-    while (m_vol->m_blockDev->isBusy()) {
-      if ((millis() - t0) > SD_READ_TIMEOUT) {
-        // busy for too long ?
-        return 0;
-      }
-      yield();
-    }
   }
 
   // seek to end of file if append flag

--- a/src/FatLib/FatFile.cpp
+++ b/src/FatLib/FatFile.cpp
@@ -1500,17 +1500,14 @@ size_t FatFile::write(const void* buf, size_t nbyte) {
 int FatFile::availableSpaceForWrite() {
   // error if not a normal file or is read-only
   if (!isWritable() || m_vol->m_blockDev->isBusy()) {
-    // error if not a normal file or is read-only
     return 0;
   }
-
   // seek to end of file if append flag
   if ((m_flags & FILE_FLAG_APPEND)) {
     if (!seekSet(m_fileSize)) {
       return 0;
     }
   }
-
   // remaining space in current sector
   uint16_t sectorOffset = m_curPosition & m_vol->sectorMask();
   int afw = m_vol->bytesPerSector() - sectorOffset - 1;


### PR DESCRIPTION
*edited*:

Prevent from returning always 0 when something can be really written.
When the current sector is full, FS available space is checked before returning a new full sector available for write (or 0 when FS is indeed full).

Related: https://github.com/esp8266/Arduino/issues/8055
