### PR TITLE
Workaround for timeout yield() removal

### DIFF
--- a/src/SpiDriver/SdSpiESP.cpp
+++ b/src/SpiDriver/SdSpiESP.cpp
@@ -26,6 +26,11 @@
 #include "SdSpiDriver.h"
 #if defined(SD_USE_CUSTOM_SPI) && (defined(ESP8266) || defined(ESP32))
 #define ESP_UNALIGN_OK 1
+
+//------------------------------------------------------------------------------
+static void SdSpiArduinoYield() {
+  optimistic_yield(WDT_YIELD_TIME_MILLIS * 1000);
+}
 //------------------------------------------------------------------------------
 void SdSpiArduinoDriver::activate() {
   m_spi->beginTransaction(m_spiSettings);
@@ -49,10 +54,12 @@ void SdSpiArduinoDriver::deactivate() {
 }
 //------------------------------------------------------------------------------
 uint8_t SdSpiArduinoDriver::receive() {
+  SdSpiArduinoYield();
   return m_spi->transfer(0XFF);
 }
 //------------------------------------------------------------------------------
 uint8_t SdSpiArduinoDriver::receive(uint8_t* buf, size_t count) {
+  SdSpiArduinoYield();
 #if ESP_UNALIGN_OK
   m_spi->transferBytes(nullptr, buf, count);
 #else  // ESP_UNALIGN_OK
@@ -75,10 +82,12 @@ uint8_t SdSpiArduinoDriver::receive(uint8_t* buf, size_t count) {
 }
 //------------------------------------------------------------------------------
 void SdSpiArduinoDriver::send(uint8_t data) {
+  SdSpiArduinoYield();
   m_spi->transfer(data);
 }
 //------------------------------------------------------------------------------
 void SdSpiArduinoDriver::send(const uint8_t* buf , size_t count) {
+  SdSpiArduinoYield();
 #if !ESP_UNALIGN_OK
   // Adjust to 32-bit alignment.
   while ((reinterpret_cast<uintptr_t>(buf) & 0X3) && count) {


### PR DESCRIPTION
See https://github.com/esp8266/Arduino/issues/8822

From my understanding, upstream chose to remove some platform specific code and implicit yielding in timeouts.

Looking at a similar code for Teensy...
Since we definitely know that things go through the driver, make yielding there and make use our optimistic variant to delay every ~100ms like it did before