### PR TITLE
ArduinoFiles.h needs to explicitly 'override' virtual methods

### DIFF
--- a/src/common/ArduinoFiles.h
+++ b/src/common/ArduinoFiles.h
@@ -44,14 +44,22 @@ class PrintFile : public print_t, public BaseFile {
  public:
   using BaseFile::clearWriteError;
   using BaseFile::getWriteError;
-  using BaseFile::read;
-  using BaseFile::write;
+
   /** Write a single byte.
    * \param[in] b byte to write.
    * \return one for success.
    */
-  size_t write(uint8_t b) {
+  size_t write(uint8_t b) override {
     return BaseFile::write(&b, 1);
+  }
+
+  /** Write data to an open file.
+   * \param[in] buffer pointer
+   * \param[in] size of the buffer
+   * \return number of bytes actually written
+   */
+  size_t write(const uint8_t* buffer, size_t size) override {
+    return BaseFile::write(buffer, size);
   }
 };
 //------------------------------------------------------------------------------
@@ -64,19 +72,17 @@ class StreamFile : public stream_t, public BaseFile {
  public:
   using BaseFile::clearWriteError;
   using BaseFile::getWriteError;
-  using BaseFile::read;
-  using BaseFile::write;
 
   StreamFile() {}
 
   /** \return number of bytes available from the current position to EOF
    *   or INT_MAX if more than INT_MAX bytes are available.
    */
-  int available() {
+  int available() override {
     return BaseFile::available();
   }
   /** Ensure that any bytes written to the file are saved to the SD card. */
-  void flush() {
+  void flush() override {
     BaseFile::sync();
   }
   /** This function reports if the current file is a directory or not.
@@ -98,7 +104,7 @@ class StreamFile : public stream_t, public BaseFile {
    *
    * \return The byte if no error and not at eof else -1;
    */
-  int peek() {
+  int peek() override {
     return BaseFile::peek();
   }
   /** \return the current file position. */
@@ -110,9 +116,19 @@ class StreamFile : public stream_t, public BaseFile {
    * \return For success return the next byte in the file as an int.
    * If an error occurs or end of file is reached return -1.
    */
-  int read() {
+  int read() override {
     return BaseFile::read();
   }
+
+  /** Read the N bytes from a file.
+   *
+   * \return For success return the number of read bytes.
+   * If an error occurs or end of file is reached return -1.
+   */
+  int read(uint8_t* buffer, size_t size) override {
+    return BaseFile::read(buffer, size);
+  }
+
   /** Rewind a file if it is a directory */
   void rewindDirectory() {
     if (BaseFile::isDir()) {
@@ -138,7 +154,7 @@ class StreamFile : public stream_t, public BaseFile {
    * Use getWriteError to check for errors.
    * \return 1 for success and 0 for failure.
    */
-  size_t write(uint8_t b) {
+  size_t write(uint8_t b) override {
     return BaseFile::write(b);
   }
   /** Write data to an open file.
@@ -153,7 +169,7 @@ class StreamFile : public stream_t, public BaseFile {
    * \return For success write() returns the number of bytes written, always
    * \a size.
    */
-  size_t write(const uint8_t* buffer, size_t size) {
+  size_t write(const uint8_t* buffer, size_t size) override {
     return BaseFile::write(buffer, size);
   }
 };

--- a/src/common/ArduinoFiles.h
+++ b/src/common/ArduinoFiles.h
@@ -45,6 +45,10 @@ class PrintFile : public print_t, public BaseFile {
   using BaseFile::clearWriteError;
   using BaseFile::getWriteError;
 
+  /** Ensure that any bytes written to the file are saved to the SD card. */
+  void flush() override {
+    BaseFile::sync();
+  }
   /** Write a single byte.
    * \param[in] b byte to write.
    * \return one for success.
@@ -125,8 +129,18 @@ class StreamFile : public stream_t, public BaseFile {
    * \return For success return the number of read bytes.
    * If an error occurs or end of file is reached return -1.
    */
+  size_t readBytes(uint8_t* buffer, size_t size) {
+    return BaseFile::read((void*)buffer, size);
+  }
+
+  // esp8266/Arduino - overload for Stream.h
+  size_t readBytes(char* buffer, size_t size) {
+      return readBytes((uint8_t*)buffer, size);
+  }
+
+  // esp8266/Arduino - overload for StreamDev.h
   int read(uint8_t* buffer, size_t size) override {
-    return BaseFile::read(buffer, size);
+    return BaseFile::read((void*)buffer, size);
   }
 
   /** Rewind a file if it is a directory */

--- a/src/common/ArduinoFiles.h
+++ b/src/common/ArduinoFiles.h
@@ -135,7 +135,7 @@ class StreamFile : public stream_t, public BaseFile {
 
   // esp8266/Arduino - overload for Stream.h
   size_t readBytes(char* buffer, size_t size) {
-      return readBytes((uint8_t*)buffer, size);
+    return BaseFile::read((void*)buffer, size);
   }
 
   // esp8266/Arduino - overload for StreamDev.h


### PR DESCRIPTION
Since GCC is very nice and does not force you to write it, and this worked just fine with the provided implementation.
However, GCC ≥13 and -Werror would trigger -Woverloaded-virtual with this impl (testing ESP8266 host builds rn)

Removed method inheritance done with 'using Base = ...' that overlaps with Stream & Print virtuals, plus changed methods in the actual class base.

*(I am also not sure what is the upstream policy on PRs, since the last time I looked everything is just closed immediately :shrug:. but i would wager this would be fixed as soon as gcc is upgrade is more widespread)*