### PR TITLE
Mount single-FAT SD cards (backport SdFat 2.3.1 fatCount fix)

### DIFF
--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -431,10 +431,12 @@ bool FatPartition::init(FsBlockDevice* dev, uint8_t part, uint32_t volStart) {
     goto fail;
   }
   bpb = reinterpret_cast<BpbFat32_t*>(pbs->bpb);
-  if (bpb->fatCount != 2 || getLe16(bpb->bytesPerSector) != m_bytesPerSector) {
+  if ((bpb->fatCount != 1 && bpb->fatCount != 2) ||
+      getLe16(bpb->bytesPerSector) != m_bytesPerSector) {
     DBG_FAIL_MACRO;
     goto fail;
   }
+  m_fatCount = bpb->fatCount;
   m_sectorsPerCluster = bpb->sectorsPerCluster;
   m_clusterSectorMask = m_sectorsPerCluster - 1;
   // determine shift that is same as multiply by m_sectorsPerCluster
@@ -456,7 +458,7 @@ bool FatPartition::init(FsBlockDevice* dev, uint8_t part, uint32_t volStart) {
   m_rootDirEntryCount = getLe16(bpb->rootDirEntryCount);
 
   // directory start for FAT16 dataStart for FAT32
-  m_rootDirStart = m_fatStartSector + 2 * m_sectorsPerFat;
+  m_rootDirStart = m_fatStartSector + m_fatCount * m_sectorsPerFat;
   // data start for FAT16 and FAT32
   m_dataStartSector =
       m_rootDirStart +

--- a/src/FatLib/FatPartition.h
+++ b/src/FatLib/FatPartition.h
@@ -98,7 +98,7 @@ class FatPartition {
     return cacheClear();
   }
   /** \return The number of File Allocation Tables. */
-  uint8_t fatCount() const { return 2; }
+  uint8_t fatCount() const { return m_fatCount; }
   /** \return The logical sector number for the start of the first FAT. */
   uint32_t fatStartSector() const { return m_fatStartSector; }
   /** \return The FAT type of the volume. Values are 12, 16 or 32. */
@@ -160,6 +160,7 @@ class FatPartition {
   uint8_t m_clusterSectorMask;       // Mask to extract sector of cluster.
   uint8_t m_sectorsPerClusterShift;  // Cluster count to sector count shift.
   uint8_t m_fatType = 0;             // Volume type (12, 16, OR 32).
+  uint8_t m_fatCount = 2;            // Number of FATs (1 or 2). SdFat 2.3.1.
   uint16_t m_rootDirEntryCount;      // Number of entries in FAT16 root dir.
   uint32_t m_allocSearchStart;       // Start cluster for alloc search.
   uint32_t m_sectorsPerFat;          // FAT size in sectors
@@ -200,7 +201,9 @@ class FatPartition {
 #if USE_SEPARATE_FAT_CACHE
   FsCache m_fatCache;
   uint8_t* fatCachePrepare(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if (m_fatCount == 2) {
+      options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    }
     return m_fatCache.prepare(sector, options);
   }
   bool cacheSync() {
@@ -208,7 +211,9 @@ class FatPartition {
   }
 #else   // USE_SEPARATE_FAT_CACHE
   uint8_t* fatCachePrepare(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if (m_fatCount == 2) {
+      options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    }
     return dataCachePrepare(sector, options);
   }
   bool cacheSync() { return m_cache.sync() && syncDevice(); }


### PR DESCRIPTION
## What I hit

I maintain a fork of the IoTaWatt ESP8266 firmware and moved it from the core 2.4 toolchain to core 3.x, which ships SdFat 2.x where the stock firmware used 1.x. Checking SD-card compatibility after the move, I found that cards formatted with a single FAT table no longer mount: `FatPartition::init()` rejects them at the `bpb->fatCount != 2` check and returns failure, though the volume is otherwise valid. A card made with `mkfs.fat -F 32 -f 1` reproduces it every time, and the same card reformatted with two FATs mounts fine. SdFat 1.x accepted any nonzero FAT count, so this is a regression from the 1.x to 2.x rewrite, which requires exactly two.

## The fix

greiman/SdFat fixed this in 2.3.1 (commit cda05731). I backported the `FatPartition` part of that change onto the current tree (2.2.2). The five edits depend on each other:

1. Accept a `fatCount` of 1 or 2 in the BPB validation, instead of exactly 2.
2. Store the count in a new `m_fatCount` member.
3. Compute the FAT16 root-directory start from `m_fatCount * m_sectorsPerFat`, instead of a hardcoded `2 *`.
4. Return the real count from `fatCount()`, instead of a hardcoded `2`.
5. Skip the `CACHE_STATUS_MIRROR_FAT` write in both `fatCachePrepare()` overloads when there is one FAT.

Item 5 is what prevents corruption: on a single-FAT card the mirror write lands past the only FAT, inside the root-directory and data region, and overwrites it on the first FAT update. Relaxing the mount check on its own, without items 3 and 5, mounts the card with the wrong layout and corrupts it on first write, so I cannot split them.

## How I tested it

I verified on ESP8266 hardware that a single-FAT card (`mkfs.fat -F 32 -f 1`) which fails to mount on the stock 2.x tree mounts and reads and writes correctly with this change, and that a normal two-FAT card is unchanged. I have also run these same five edits as a build-time patch against the 2.1.1 copy the core currently ships, in firmware on several always-on devices, with no SD regressions.

## Formatting

I ran `clang-format -style=Google` over both touched files and they re-check clean, and they pass `cpplint` with the repo's own filters (`-build/include,-runtime/references,-build/header_guard`) with zero warnings, so the diff matches the 2.2.2 style and does not reintroduce the static-analysis warnings that reformat addressed.
